### PR TITLE
Add estimated remaining time

### DIFF
--- a/cv.c
+++ b/cv.c
@@ -26,6 +26,7 @@
 #include <limits.h>
 #include <ctype.h>
 #include <libgen.h>
+#include <time.h>
 
 #include <getopt.h>
 
@@ -331,6 +332,16 @@ if (optind < argc) {
 
 }
 
+void print_eta(time_t seconds)
+{
+struct tm *p = gmtime(&seconds);
+
+printf(" eta ");
+if (p->tm_yday)
+    printf("%d day%s, ", p->tm_yday, p->tm_yday > 1 ? "s" : "");
+printf("%d:%02d:%02d\n", p->tm_hour, p->tm_min, p->tm_sec);
+}
+
 // TODO: deal with --help
 
 int main(int argc, char *argv[])
@@ -464,6 +475,9 @@ for (i = 0 ; i < result_count ; i++) {
 
         format_size(bytes_per_sec, ftroughput);
         printf(" %s/s", ftroughput);
+        if (bytes_per_sec && fdinfo.size - fdinfo.pos > 0) {
+            print_eta((fdinfo.size - fdinfo.pos) / bytes_per_sec);
+        }
     }
 
 


### PR DESCRIPTION
Really simple patch to add an ETA when this one is greater than 0 (just to not print an ETA of 0 when we don't know the destination size like on a wget download)

Preview of ETA on a scp copy

> $ ./cv -c scp -w
> [26040] scp [...]/ubuntu-14.04-desktop-i386.iso 4.5% (44 MiB / 970 MiB) 3.0 MiB/s eta 0:05:08
