### PR TITLE
and ltinfo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 OBJ=cv
 CFLAGS+=-g -Wall -D_FILE_OFFSET_BITS=64
-LFLAGS=-lncurses -lm
+LFLAGS=-lncurses -lm -ltinfo
 PREFIX = $(DESTDIR)/usr/local
 BINDIR = $(PREFIX)/bin
 


### PR DESCRIPTION
please check:http://stackoverflow.com/questions/9541679/undefined-reference-to-stdscr

with ncurse 5.9-r3. we should and ltinfo.
