### PR TITLE
Add override directive to makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ override CFLAGS += -g -Wall -D_FILE_OFFSET_BITS=64
 override LFLAGS += -lncurses -lm
 PREFIX ?= /usr/local
 BINDIR = $(PREFIX)/bin
+MANDIR = $(PREFIX)/share/man/man1
 
 $(OBJ) : cv.o sizes.o hlist.o
 	$(CC) -Wall $^ -o $@ $(LFLAGS)
@@ -11,7 +12,11 @@ $(OBJ) : cv.o sizes.o hlist.o
 clean :
 	rm -f *.o $(OBJ)
 install : $(OBJ)
-	@echo "Installing to $(DESTDIR)$(BINDIR) ..."
+	@echo "Installing program to $(DESTDIR)$(BINDIR) ..."
 	@mkdir -p $(DESTDIR)$(BINDIR)
 	@install -pm0755 $(OBJ) $(DESTDIR)$(BINDIR)/$(TARGET) || \
+	echo "Failed. Try "make PREFIX=~ install" ?"
+	@echo "Installing manpage to $(DESTDIR)$(MANDIR) ..."
+	@mkdir -p $(DESTDIR)$(MANDIR)
+	@install -pm0644 cv.1 $(DESTDIR)$(MANDIR)/ || \
 	echo "Failed. Try "make PREFIX=~ install" ?"


### PR DESCRIPTION
Add override directive to avoid flags overridden by custom settings.

Then make CFLAGS="$(XXX)" will honor the existing flags in the makefile defined by upstream.
