### PR TITLE
Add bsdtar, bsdcpio, and cpio to proc_names

### DIFF
--- a/cv.c
+++ b/cv.c
@@ -53,7 +53,8 @@
 
 char *proc_names[] = {"cp", "mv", "dd", "tar", "gzip", "gunzip", "cat",
     "grep", "fgrep", "egrep", "cut", "sort", "xz", "md5sum", "sha1sum",
-    "sha224sum", "sha256sum", "sha384sum", "sha512sum", "adb", NULL
+    "sha224sum", "sha256sum", "sha384sum", "sha512sum", "adb", "bsdtar",
+    "cpio", "bsdcpio", NULL
 };
 
 static int proc_specifiq_name_cnt;


### PR DESCRIPTION
bsdtar and bsdcpio are libarchive's implementations of
tar and cpio.
