### PR TITLE
Small, but nice formatting change when no compatible process is currently running.

### DIFF
--- a/progress.c
+++ b/progress.c
@@ -638,9 +638,8 @@ if (!pid_count) {
     }
     nfprintf(stderr,"No command currently running: ");
 
-    int len_proc_names = sizeof(proc_names) / sizeof(proc_names[0]);
     for (i = 0 ; proc_names[i] ; i++) {
-        if (i == len_proc_names - 2) // if last proc name, finish with a period (.)
+        if (i == DIM(proc_names) - 2) // if last proc name, finish with a period (.)
             nfprintf(stderr,"%s. ", proc_names[i]);
         else // comma separate instead
             nfprintf(stderr,"%s, ", proc_names[i]);

--- a/progress.c
+++ b/progress.c
@@ -637,10 +637,15 @@ if (!pid_count) {
 	refresh();
     }
     nfprintf(stderr,"No command currently running: ");
+
+    int len_proc_names = sizeof(proc_names) / sizeof(proc_names[0]);
     for (i = 0 ; proc_names[i] ; i++) {
-        nfprintf(stderr,"%s, ", proc_names[i]);
+        if (i == len_proc_names - 2) // if last proc name, finish with a period (.)
+            nfprintf(stderr,"%s. ", proc_names[i]);
+        else // comma separate instead
+            nfprintf(stderr,"%s, ", proc_names[i]);
     }
-    nfprintf(stderr,"exiting.\n");
+    nfprintf(stderr,"Exiting.\n");
     return 0;
 }
 

--- a/sizes.c
+++ b/sizes.c
@@ -2,8 +2,6 @@
 
 // Thanks to Jonathan Leffler for this code
 
-#define DIM(x) (sizeof(x)/sizeof(*(x)))
-
 static const char     *sizes[]   = { "EiB", "PiB", "TiB", "GiB", "MiB", "KiB", "B" };
 static const uint64_t  exbibytes = 1024ULL * 1024ULL * 1024ULL *
                                    1024ULL * 1024ULL * 1024ULL;

--- a/sizes.h
+++ b/sizes.h
@@ -6,6 +6,8 @@
 #include <stdlib.h>
 #include <string.h>
 
+#define DIM(x) (sizeof(x)/sizeof(*(x)))
+
 void format_size(uint64_t size, char *result);
 
 #endif


### PR DESCRIPTION
Inserts a period after the last proc_name instead of a comma, so that "exiting" doesn't look like a proc_name itself.