### PR TITLE
Add support for g-prefixed GNU coreutils

### DIFF
--- a/progress.c
+++ b/progress.c
@@ -54,7 +54,10 @@
 
 char *proc_names[] = {"cp", "mv", "dd", "tar", "gzip", "gunzip", "cat",
     "grep", "fgrep", "egrep", "cut", "sort", "xz", "md5sum", "sha1sum",
-    "sha224sum", "sha256sum", "sha384sum", "sha512sum", "adb", NULL
+    "sha224sum", "sha256sum", "sha384sum", "sha512sum", "adb",
+    // Coreutils with 'g' prefixes (MacPorts, BSD, Solaris, etc)
+    "gcp", "gmv", "gdd", "gnutar", "gcat", "gcut", "gsort", "gmd5sum",
+    "gsha1sum", "gsha224sum", "gssha256sum", "gsha384sum", "gsha512sum", NULL
 };
 
 static int proc_specifiq_name_cnt;


### PR DESCRIPTION
Prefixed versions may be used on a system that has a base BSD coreutils, such as OS X where using MacPorts GNU Coreutils can be installed, but by default are prefixed with 'g'. Even if PATH is overriden, the path used contains symbolic links to the g-prefixed binaries, which means the g-prefixed name is what will appear in the process list.

This also can apply to Solaris.