### PR TITLE
strlen(s) == 0 is slow; instead, check \0 position

### DIFF
--- a/progress.c
+++ b/progress.c
@@ -135,7 +135,7 @@ char exe[MAXPATHLEN + 1];
 
 exe[0] = '\0';
 proc_name(pid, exe, sizeof(exe));
-if (strlen(exe) == 0)
+if (exe[0] == '\0')
     return 0;
 
 pid_list[0].pid = pid;


### PR DESCRIPTION
The expression

    if( strlen(exe) == 0 ) ...

can be slow in the case where the expression evaluates to false, because `strlen()` traverses through its entire string argument. C strings are 0-terminated, so it would be faster to check

    if( exe[0] == '\0' )

in both true and false cases.

Also, I think `proc_name()` returns an error state. Would it make sense to look at that?