### PR TITLE
Remove spaces between emboldened text and parentheses in manpage

### DIFF
--- a/progress.1
+++ b/progress.1
@@ -35,9 +35,7 @@ cat, etc.) currently running on your system and displays the
 percentage of copied data.
 
 It can now also estimate throughput (using flag
-.B \-w
-).
-
+.BR \-w ).
 
 .SH OPTIONS
 .TP
@@ -52,16 +50,14 @@ estimate I/O throughput and estimated remaining time (slower display)
 .TP
 .B \-W (\-\-wait\-delay secs)
 wait 'secs' seconds for I/O estimation (implies
-.B \-w
-)
+.BR \-w )
 .TP
 .B \-m (\-\-monitor)
 loop while monitored processes are still running
 .TP
 .B \-M (\-\-monitor\-continuously)
 like monitor but never stop (similar to
-.B watch progress
-)
+.BR "watch progress" )
 .TP
 .B \-c (\-\-command cmd)
 monitor only this command name (ex: firefox). This option can be used multiple


### PR DESCRIPTION
Before:

> It can now also estimate throughput (using flag **-w** ).

> wait 'secs' seconds for I/O estimation (implies **-w** )

> like monitor but never stop (similar to **watch progress** )

After: 

> It can now also estimate throughput (using flag **-w**).

> wait 'secs' seconds for I/O estimation (implies **-w**)

> like monitor but never stop (similar to **watch progress**)