### PR TITLE
Makefile: set `-g` flag only if CFLAGS not set

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 OBJ = progress
-override CFLAGS += -g -Wall -D_FILE_OFFSET_BITS=64
+CFLAGS ?= -g
+override CFLAGS += -Wall -D_FILE_OFFSET_BITS=64
 override LDFLAGS += -lm
 UNAME := $(shell uname)
 PKG_CONFIG ?= pkg-config


### PR DESCRIPTION
As the flag is not required for the program to compile/run correctly, some distros do not allow it to be set implicitly, eg. Gentoo.