### PR TITLE
Added verifying agains nullptr

### DIFF
--- a/progress.c
+++ b/progress.c
@@ -746,9 +746,10 @@ if (!pid_count) {
     }
     if (proc_specifiq_pid_cnt) {
         nfprintf(stderr, "No such pid: ");
-        for (i = 0 ; i < proc_specifiq_pid_cnt; ++i) {
-            nfprintf(stderr, "%d, ", proc_specifiq_pid[i]);
-        }
+	if (proc_specifiq_pid)
+            for (i = 0 ; i < proc_specifiq_pid_cnt; ++i) {
+                nfprintf(stderr, "%d, ", proc_specifiq_pid[i]);
+            }
     }
     if (proc_specifiq_name_cnt)
     {


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. Errors, found using PVS-Studio:
progress/progress.c 750     err     V595 The 'proc_specifiq_pid' pointer was utilized before it was verified against nullptr. Check lines: 750, 760.