### PR TITLE
Sort and move content of default_proc_names to separated header file.

### DIFF
--- a/proc_names.h
+++ b/proc_names.h
@@ -1,0 +1,55 @@
+/*
+   Copyright (C) 2016 Xfennec, CQFD Corp.
+
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+"7z",
+"7za",
+"adb",
+"bunzip2",
+"bzcat",
+"bzip2",
+"cat", 
+"cp",
+"cut",
+"dd",
+"egrep",
+"fgrep",
+"gpg",
+"grep",
+"gunzip",
+"gzip",
+"lzcat",
+"lzma",
+"md5sum",
+"mv",
+"pbzip2",
+"pigz",	
+"pixz",
+"rsync",
+"scp",
+"sha1sum",
+"sha224sum",
+"sha256sum",
+"sha384sum",
+"sha512sum",
+"sort",
+"split",
+"tar", 
+"unlzma",
+"unxz",
+"unzip",
+"xz",
+"zcat",
+"zip",

--- a/progress.c
+++ b/progress.c
@@ -57,13 +57,8 @@
 // list and generate it at runtime.
 static int proc_names_cnt;
 static char **proc_names;
-char *default_proc_names[] = {"cp", "mv", "dd", "tar", "cat", "rsync",
-    "grep", "fgrep", "egrep", "cut", "sort", "md5sum", "sha1sum",
-    "sha224sum", "sha256sum", "sha384sum", "sha512sum", "adb",
-    "gzip", "gunzip", "bzip2", "bunzip2", "xz", "unxz", "lzma", "unlzma", "7z", "7za",
-    "zcat", "bzcat", "lzcat",
-    "split",
-    "gpg",
+char *default_proc_names[] = {
+#include "proc_names.h"
     NULL
 };
 


### PR DESCRIPTION
This commit also adds zip, unzip, pixz, pigz, pbzip2 to the list.