### PR TITLE
add support for coreutils compiled with --enable-single-binary

### DIFF
--- a/progress.c
+++ b/progress.c
@@ -63,6 +63,7 @@ char *default_proc_names[] = {"cp", "mv", "dd", "tar", "cat", "rsync", "scp",
     "sha224sum", "sha256sum", "sha384sum", "sha512sum", "adb",
     "gzip", "gunzip", "bzip2", "bunzip2", "xz", "unxz", "lzma", "unlzma", "7z", "7za", "zip", "unzip",
     "zcat", "bzcat", "lzcat",
+    "coreutils",
     "split",
     "gpg",
 #ifdef __APPLE__


### PR DESCRIPTION
When coreutils is compiled with the `--enable-single-binary` option, all the individual commands are just symlinks to a larger single binary named "coreutils", the same way that a typical busybox binary works. In this situation, `progress` gets back the name "coreutils" instead of, for example, "dd" when reading `/proc/[pid]/exe`.

Unfortunately this means that, on systems with single-binary coreutils, all of your running commands will show up as "coreutils" instead of the command you actually typed.