### PR TITLE
Fix some unicode printing problem with ncurses #160

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,10 +8,10 @@ ifeq ($(UNAME), Linux)
     ifeq (, $(shell which $(PKG_CONFIG) 2> /dev/null))
     $(error "pkg-config command not found")
     endif
-    ifeq (, $(shell $(PKG_CONFIG) ncurses --libs 2> /dev/null))
+    ifeq (, $(shell $(PKG_CONFIG) ncursesw --libs 2> /dev/null))
     $(error "ncurses package not found")
     endif
-    override LDFLAGS += $(shell $(PKG_CONFIG) ncurses --libs)
+    override LDFLAGS += $(shell $(PKG_CONFIG) ncursesw --libs)
 endif
 ifeq ($(UNAME), Darwin)
     override LDFLAGS += -lncurses

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ How do you build it from source
 
 On FreeBSD, substitute `make` with `gmake`.
 
-It depends on library ncurses, you may have to install corresponding packages (may be something like 'libncurses5-dev' or 'ncurses-devel').
+It depends on library ncurses, you may have to install corresponding packages (may be something like 'libncurses5-dev', 'libncursesw6' or 'ncurses-devel').
 
 How do you run it
 -----------------


### PR DESCRIPTION
Change the Makefile to build with ncursesw that have wide chars support on Linux.
macOS by default seems to support widechar characters by default, so no need any changes
For FreeBSD I don't know, so I didn't touch it.