### PR TITLE
Add flag -t to adjust max pid count

### DIFF
--- a/progress.h
+++ b/progress.h
@@ -28,8 +28,6 @@
 #define PROGRESS_VERSION         "0.16"
 
 #define PROC_PATH       "/proc"
-#define MAX_PIDS        32
-#define MAX_RESULTS     32
 #define MAX_FD_PER_PID  512
 #define LINE_LEN        256
 


### PR DESCRIPTION
This is for the issue in #146 with the process count limit being hit. This PR defaults to 32 and lets the user supply their own value.

I'm unsure of the implications of making `old_results` no longer static, but changing it allows the user-supplied variable to be used instead.

Usage:
```
./progress -t 64
```

Another solution might be to scan for the processes first to get an upper count, before going on to fill the array with the process info, to not need a count supplied with >32 processes.