### PR TITLE
Add `cksum` to the list of checksum functions.

### DIFF
--- a/progress.c
+++ b/progress.c
@@ -72,7 +72,7 @@
 static int proc_names_cnt;
 static char **proc_names;
 char *default_proc_names[] = {"cp", "mv", "dd", "tar", "bsdtar", "cat", "rsync", "scp",
-    "grep", "fgrep", "egrep", "cut", "sort", "md5sum", "sha1sum",
+    "grep", "fgrep", "egrep", "cut", "sort", "cksum", "md5sum", "sha1sum",
     "sha224sum", "sha256sum", "sha384sum", "sha512sum",
 #ifdef __FreeBSD__
     "md5", "sha1", "sha224", "sha256", "sha512", "sha512t256", "rmd160",


### PR DESCRIPTION
`cksum` is present on POSIX systems and the *majority* of Linux systems. Hence, MacOS has it too. I would like to have this merged in as a default; I use `cksum` frequently because it's 10x faster than `md5sum` for non-secure checksums.

POSIX 1003.2

https://en.wikipedia.org/wiki/Cksum
https://pubs.opengroup.org/onlinepubs/009696799/utilities/cksum.html